### PR TITLE
Add height/width attribute to amp-img tag when "w" or "h" parameter set.

### DIFF
--- a/layouts/shortcodes/img.amp.html
+++ b/layouts/shortcodes/img.amp.html
@@ -1,5 +1,5 @@
 <figure{{ if .Get "class" }} class="{{ .Get "class" }}"{{ end }}>
-  <amp-img src="{{ $.Site.BaseURL }}{{ .Get "src" }}" alt="{{ .Get "caption" }}" width={{ .Get "w" }} height={{ .Get "h" }} layout="responsive"></amp-img>
+  <amp-img src="{{ $.Site.BaseURL }}{{ .Get "src" }}" alt="{{ .Get "caption" }}"{{ if .Get "w" }} width={{ .Get "w" }} {{ end }}{{ if .Get "h" }} height={{ .Get "h" }} {{ end }} layout="responsive"></amp-img>
   {{ if .Get "caption" }}
   <figcaption>
     {{ if .Get "href" }}


### PR DESCRIPTION
Fix problem `width= height=` is wrong.

```
<amp-img src="path_to_image" alt=""
width= height= layout="responsive"></amp-img>
```