### PR TITLE
Add article count to sidebar tags

### DIFF
--- a/layouts/partials/taxonomy.html
+++ b/layouts/partials/taxonomy.html
@@ -2,7 +2,7 @@
   <header>{{ .key | upper }}</header>
   <div>
     <ul class="terms">
-      {{ range first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name }}</a></li>{{ end }}
+      {{ range $key, $value := first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name }} ({{ $value.Count }})</a></li>{{ end }}
     </ul>
   </div>
 </section>

--- a/layouts/partials/taxonomy.html
+++ b/layouts/partials/taxonomy.html
@@ -2,7 +2,7 @@
   <header>{{ .key | upper }}</header>
   <div>
     <ul class="terms">
-      {{ range $key, $value := first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name }} ({{ $value.Count }})</a></li>{{ end }}
+      {{ range $key, $value := first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name }} <span class="count">({{ $value.Count }})</span></a></li>{{ end }}
     </ul>
   </div>
 </section>


### PR DESCRIPTION
Sidebar `categories` and `tags` are sorted by article count, so I thought count should be shown.
How do you think?