### PR TITLE
Modify tags uppercase

### DIFF
--- a/layouts/partials/taxonomy.html
+++ b/layouts/partials/taxonomy.html
@@ -2,7 +2,7 @@
   <header>{{ .key | upper }}</header>
   <div>
     <ul class="terms">
-      {{ range first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name }}</a></li>{{ end }}
+      {{ range first 10 .value.ByCount }}<li><a href="{{ $.baseurl}}{{ $.key }}/{{ .Name | urlize }}">{{ .Name | upper }}</a></li>{{ end }}
     </ul>
   </div>
 </section>


### PR DESCRIPTION
`CATEGORY` and `TAG` characters in sidebar is UPPERCASE, so their entity also should be UPPERCASE, don't you think so?