### PR TITLE
use AlternativeOutputFormats

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -6,7 +6,9 @@
 {{ .Hugo.Generator }}
 
 <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}images/logo.png">
-{{ with .RSSLink }}<link rel="alternate" type="application/rss+xml" title="RSS" href="{{ . }}">{{ end }}
 
 <link rel="canonical" href="{{ .Permalink }}">
+{{ range .AlternativeOutputFormats -}}
+	<link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}" title="{{ $.Site.Title | safeHTML }}">
+{{ end -}}
 


### PR DESCRIPTION
`RSSLink` は非推奨であるため変更。

`AlternativeOutputFormats` を使うことによって `link rel="amphtml"` にも対応