### PR TITLE
Change Google Analytics

### DIFF
--- a/layouts/_default/baseof.amp.html
+++ b/layouts/_default/baseof.amp.html
@@ -5,7 +5,10 @@
 
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
+    {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+    <meta name="amp-google-client-id-api" content="googleanalytics">
+    {{ end }}
 
     {{ with .Site.Params.googlefonts }}
     <link href="{{ . }}" rel="stylesheet">
@@ -25,7 +28,7 @@
   </head>
 
   <body>
-    {{ if ne (getenv "HUGO_ENV") "DEV" }}
+    {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
     <amp-analytics type="googleanalytics" id="analytics1">
       <script type="application/json"> { "vars": { "account": {{ .Site.GoogleAnalytics }}}, "triggers": { "trackPageview": { "on": "visible", "request": "pageview" } } }
       </script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,13 +17,16 @@
 {{ with .Site.Params.fontfamily }} body { font-family: {{ . | safeCSS }}; } {{ end }}
 {{ with .Site.Params.logofontfamily }} .h-logo { font-family: {{ . | safeCSS }}; } {{ end }}
     </style>
+{{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+<script>
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', {{ .Site.GoogleAnalytics }}, 'auto', {'useAmpClientId': true});
+ga('send', 'pageview');
+</script>
+{{ end }}
   </head>
-
   <body>
-    {{ if ne (getenv "HUGO_ENV") "DEV" }}
-    {{ template "_internal/google_analytics.html" . }}
-    {{ end }}
-
     <header class="l-header">
       <div class="l-container">
         <div class="logo">


### PR DESCRIPTION
AMP HTML に対応するために

https://www.suzukikenichi.com/blog/google-analytics-lets-you-opt-in-amp-client-id-api/