### PR TITLE
Fix WARNING

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,10 @@
 
     <div class="articles">
       <div class="mrow">
-        {{ range (.Paginate .Data.Pages).Pages }}
+        {{- $pctx := . -}}
+        {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+        {{- $pages := $pctx.RegularPages -}}
+        {{ range $pages }}
         <div class="mcol c6">{{ .Render "li" }}</div>
         {{ end }}
       </div>

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Grid based theme for Hugo."
 homepage = "https://github.com/dim0627/hugo_theme_robust"
 tags = ["blog"]
 features = ["responsive", "thumbnail", "grid", "syntax highlight", "structured data", "ogp", "twitter cards"]
-min_version = 0.53
+min_version = 0.57.2
 
 [author]
 name = "Daisuke Tsuji"


### PR DESCRIPTION
- https://github.com/gohugoio/hugo/releases/tag/v0.57.2

> In the next Hugo version (0.58.0) we will change how $home.Pages behaves. If you want to list all regular pages, replace .Pages or .Data.Pages with .Site.RegularPages in your home page template.

`RegularPages` を使うように変更