### PR TITLE
Fix the number of articles on the list page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,10 +12,7 @@
 
     <div class="articles">
       <div class="mrow">
-        {{- $pctx := . -}}
-        {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
-        {{- $pages := $pctx.RegularPages -}}
-        {{ range $pages }}
+        {{ range .Paginator.Pages }}
         <div class="mcol c6">{{ .Render "li" }}</div>
         {{ end }}
       </div>


### PR DESCRIPTION
こんにちは。リストページで表示される記事の数がおかしかったので修正してみました。

[hugoBasicExample](https://github.com/gohugoio/hugoBasicExample)で動作確認しました。
修正前：ルートページも/page/2/も/page/3/も、毎回記事11件が全て表示される
修正後：config.tomlで指定された`paginate = 3`に従って、3枚づつ順に表示される