### PR TITLE
Fix Escape Sequence in single_json_ld.html (fixes #56)

### DIFF
--- a/layouts/partials/single_json_ld.html
+++ b/layouts/partials/single_json_ld.html
@@ -6,7 +6,7 @@
       "@type": "WebPage",
       "@id":"{{ .Site.BaseURL }}"
     },
-    "headline": "{{ .Title }} - {{ .Site.Title }}",
+    "headline": {{ print .Title "-" .Site.Title | jsonify | safeJS }},
     "image": {
       "@type": "ImageObject",
       "url": "{{ .Site.BaseURL }}{{ .Params.thumbnail | default "images/default.png" }}",
@@ -17,11 +17,11 @@
     "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05JST" }}",
     "author": {
       "@type": "Person",
-      "name": "{{ .Site.Title }}"
+      "name": {{ .Site.Title | jsonify | safeJS }}
     },
     "publisher": {
       "@type": "Organization",
-      "name": "{{ .Site.Title }}",
+      "name": {{ .Site.Title | jsonify | safeJS }},
       "logo": {
         "@type": "ImageObject",
         "url": "{{ .Site.BaseURL }}images/logo.png",


### PR DESCRIPTION
Issue [#56](https://github.com/dim0627/hugo_theme_robust/issues/56) を修正してみました。

修正前のアウトプット: 
```
  {
    ...
    "headline": "Emoji Support - zzzmisa\x27s blog",
    ...
  }
```

修正後のアウトプット: 
```
  {
    ...
    "headline": "Emoji Support - zzzmisa's blog",
    ...
  }
```