### PR TITLE
Fix duplicate tags (fixes #57)

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,6 @@
 {{ define "title" }}{{ .Title }} - {{ end }}
 
 {{ define "meta" }}
-{{ range .AlternativeOutputFormats }}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
-{{ end }}
 {{ partial "single_meta.html" . }}
 {{ partial "single_json_ld.html" . }}
 {{ end }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -7,7 +7,6 @@
 
 <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}images/logo.png">
 
-<link rel="canonical" href="{{ .Permalink }}">
 {{ range .AlternativeOutputFormats }}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}" title="{{ $.Site.Title | safeHTML }}">
 {{ end }}


### PR DESCRIPTION
Issue [#57](https://github.com/dim0627/hugo_theme_robust/issues/57) の修正です。
ダブっていた部分を消してみました。

■修正前

public/about/index.html: 
```
...
<link rel="canonical" href="https://gohugo.io/about/">

<link rel="amphtml" type="text/html" href="https://gohugo.io/amp/about/" title="Hugo Themes">
...
<link rel="amphtml" type="text/html" href="https://gohugo.io/amp/about/">
...
```

public/amp/about/index.html: 
```
...
<link rel="canonical" href="https://gohugo.io/amp/about/">

<link rel="canonical" type="text/html" href="https://gohugo.io/about/" title="Hugo Themes">
...
```
■修正後

public/about/index.html: 
```
...
<link rel="amphtml" type="text/html" href="https://gohugo.io/amp/about/" title="Hugo Themes">
...
```
public/amp/about/index.html: 

```
...
<link rel="canonical" type="text/html" href="https://gohugo.io/about/" title="Hugo Themes">
...
```
