### PR TITLE
Update Google Analytics code snippet

### DIFF
--- a/layouts/_default/baseof.amp.html
+++ b/layouts/_default/baseof.amp.html
@@ -46,10 +46,18 @@
 
   <body>
     {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
-    <amp-analytics type="googleanalytics" id="analytics1">
-      <script type="application/json"> { "vars": { "account": {{ .Site.GoogleAnalytics }}}, "triggers": { "trackPageview": { "on": "visible", "request": "pageview" } } }
+    <amp-analytics type="gtag" data-credentials="include">
+      <script type="application/json">
+      {
+        "vars" : {
+          "gtag_id": "{{ .Site.GoogleAnalytics }}}",
+          "config" : {
+            "{{ .Site.GoogleAnalytics }}}": { "groups": "default" }
+          }
+        }
+      }
       </script>
-    </amp-analytics>
+      </amp-analytics>
     {{ end }}
 
     <header class="l-header">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,11 +45,14 @@
 {{ partial "custom.css" . | safeCSS }}
     </style>
 {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
-<script async src='https://www.google-analytics.com/analytics.js'></script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
 <script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', {{ .Site.GoogleAnalytics }}, 'auto', {'useAmpClientId': true});
-ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ .Site.GoogleAnalytics }}');
 </script>
 {{ end }}
   </head>


### PR DESCRIPTION
Google Analytics の コードスニペット をanalytics.js （古い仕様）から gtag.js （新しい仕様）に置き換えてみました。

Google Analytics のドキュメントはこちらです。
* [analytics.js から gtag.js に移行する](https://developers.google.com/analytics/devguides/collection/gtagjs/migration?hl=ja)
* [AMP ページにアナリティクスを追加する](https://developers.google.com/analytics/devguides/collection/amp-analytics)