### PR TITLE
Update Shortcodes section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ toc = true # Optional
 ## Image
 
 ```
-{{% img src="images/image.jpg" w="600" h="400" %}}
-{{% img src="images/image.jpg" w="600" h="400" caption="Referenced from wikipedia." href="https://en.wikipedia.org/wiki/Lorem_ipsum" %}}
+{{< img src="images/image.jpg" w="600" h="400" >}}
+{{< img src="images/image.jpg" w="600" h="400" caption="Referenced from wikipedia." href="https://en.wikipedia.org/wiki/Lorem_ipsum" >}}
 ```
 
 ![screenshot](https://raw.githubusercontent.com/dim0627/hugo_theme_robust/master/images/include-images.png)


### PR DESCRIPTION
いつもありがとうございます！
`img`のショートコードがREADMEの実装例では表示されなくなっていたので、READMEを修正しました。

修正前の記述：
```
{{% img src="images/image.jpg" w="600" h="400" %}}
```

レンダリング結果：
```
<!-- raw HTML omitted -->
<!-- raw HTML omitted -->
```

`raw HTML omitted`になる原因は、Hugo v0.60 から デフォルトのMarkdownパーサがBlackfridayからGoldmarkになったことで、Markdonw中のHTMLタグを無視するようになったからのようです。

参考：HUGO - Goldmark
https://gohugo.io/getting-started/configuration-markup/#goldmark

調べたところ、`{{%  %}}` ではなく`{{<  >}}`を使うと問題なく表示されるようでした。よって解決方法として、README内のショートコードの記述を`{{<  >}}`に修正しました。

ちなみに記事内の記述を全て書き換えるのが面倒な場合、config.toml に以下のどちかかを追記すると  `{{%  %}}`のままでも表示されます。

```
[markup.goldmark.renderer]
  unsafe = true
```
```
[markup]
  defaultMarkdownHandler = "blackfriday"
```
