### PR TITLE
Fix image aspect ratio

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -407,6 +407,7 @@ article.sn > .article-body figure img,
 article.sn > .article-body figure amp-img {
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   max-width: 100%;
+  height: 100%;
 }
 
 article.sn > .article-body figcaption {


### PR DESCRIPTION
度々失礼します。

`img`のショートコードで`w`と`h`を指定すると、スマホで見る場合など、画面の幅を狭くした時に縦横比が崩れてしまいます。
この問題を直すために、scssファイルを修正しました。

ソース：
```
{{< img src="images/default.jpg" w="600" h="400" >}}
```

縦横比が崩れる様子：
<img width="505" alt="スクリーンショット 2021-12-02 11 21 48" src="https://user-images.githubusercontent.com/1224701/144346528-531a889c-112b-4ec9-85ab-995935abbb23.png">
