### PR TITLE
Set code tag css to headings and lists

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -339,10 +339,19 @@ article.sn > .article-body em {
   color: #8bc34a;
 }
 
-article.sn > .article-body code,
-article.sn > .article-body pre {
-  font-family: Menlo, Consolas, monospace;
-  font-size: .7rem;
+article.sn > .article-body {
+  h2 code {
+    font-size: 1.1rem;
+  }
+  h1, h3, h4, h5 ,h6 {
+    code {
+      font-size: .9rem;
+    }
+  }
+  code, pre{
+    font-family: Menlo, Consolas, monospace;
+    font-size: .7rem;
+  }
 }
 
 article.sn > .article-body pre {
@@ -370,13 +379,17 @@ article.sn > .article-body pre > code {
   }
 }
 
-article.sn > .article-body p code {
-  background-color: #eceff1;
-  color: #333;
-  border-radius: 4px;
-  margin: 0 .25rem;
-  padding: .375rem;
-  white-space: nowrap;
+article.sn > .article-body {
+  p, h1, h2, h3, h4, h5 ,h6 {
+    code {
+      background-color: #eceff1;
+      color: #333;
+      border-radius: 4px;
+      margin: 0 .25rem;
+      padding: .375rem;
+      white-space: nowrap;
+    }
+  }
 }
 
 article.sn > .article-body blockquote {

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -380,7 +380,7 @@ article.sn > .article-body pre > code {
 }
 
 article.sn > .article-body {
-  p, h1, h2, h3, h4, h5 ,h6 {
+  p, h1, h2, h3, h4, h5 ,h6, li {
     code {
       background-color: #eceff1;
       color: #333;


### PR DESCRIPTION
いつもありがとうございます。素敵なテーマなのでこれからも愛用させていただきたいです！

ヘッダーとリストで、インラインコードを表示した時のCSSが無かったので設定してみました。
`font-size`の値は自信がないので、問題があれば修正いただけると幸いです。

<img width="850" alt="スクリーンショット 2022-01-06 23 27 14" src="https://user-images.githubusercontent.com/1224701/148398044-b2337773-7ecb-4b25-87d0-2cc49f655fba.png">

