### PR TITLE
Fix deprecated Google Analytics and Disqus settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ theme = "hugo_theme_robust"
 
 [services]
   [services.disqus]
-    shortname = 'UA-XXXXXXXX-XX' # Optical
+    shortname = ''
   [services.googleAnalytics]
-    id = ''
+    id = 'UA-XXXXXXXX-XX' # Optical
 
 [params]
 description = "This is site description"

--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ baseurl = "https://example.com/"
 title = "SiteTitle"
 theme = "hugo_theme_robust"
 
-googleAnalytics = "UA-XXXXXXXX-XX" # Optional
-disqusShortname = "XYW"
+[services]
+  [services.disqus]
+    shortname = 'UA-XXXXXXXX-XX' # Optical
+  [services.googleAnalytics]
+    id = ''
 
 [params]
 description = "This is site description"

--- a/layouts/_default/baseof.amp.html
+++ b/layouts/_default/baseof.amp.html
@@ -7,7 +7,7 @@
     {{ partial "meta.html" . }}
     {{ block "meta" . }}{{ end }}
 
-    {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
+    {{ if and .Site.Config.Services.GoogleAnalytics.ID (ne (getenv "HUGO_ENV") "DEV") }}
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
     <meta name="amp-google-client-id-api" content="googleanalytics">
     {{ end }}
@@ -45,14 +45,14 @@
   </head>
 
   <body>
-    {{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
+    {{ if and .Site.Config.Services.GoogleAnalytics.ID (ne (getenv "HUGO_ENV") "DEV") }}
     <amp-analytics type="gtag" data-credentials="include">
       <script type="application/json">
       {
         "vars" : {
-          "gtag_id": "{{ .Site.GoogleAnalytics }}}",
+          "gtag_id": "{{ .Site.Config.Services.GoogleAnalytics.ID }}}",
           "config" : {
-            "{{ .Site.GoogleAnalytics }}}": { "groups": "default" }
+            "{{ .Site.Config.Services.GoogleAnalytics.ID }}}": { "groups": "default" }
           }
         }
       }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -44,15 +44,15 @@
 {{ with .Site.Params.logofontfamily }} .h-logo { font-family: {{ . | safeCSS }}; } {{ end }}
 {{ partial "custom.css" . | safeCSS }}
     </style>
-{{ if and .Site.GoogleAnalytics (ne (getenv "HUGO_ENV") "DEV") }}
+{{ if and .Site.Config.Services.GoogleAnalytics.ID (ne (getenv "HUGO_ENV") "DEV") }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Config.Services.GoogleAnalytics.ID }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '{{ .Site.GoogleAnalytics }}');
+  gtag('config', '{{ .Site.Config.Services.GoogleAnalytics.ID }}');
 </script>
 {{ end }}
   </head>


### PR DESCRIPTION
こんにちは、いつもテーマを使わせていただいております。
先日hugoのバージョンをv0.136.2へ上げたところ以下のようなエラーでビルドが通りませんでした。
```console
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.137.0. 
Use .Site.Config.Services.GoogleAnalytics.ID instead. Built in 39 ms Error: error building site: logged 1 error(s)
```

そのため、Google Analyticsの設定を、非推奨となった`.Site.GoogleAnalytics`から`.Site.Config.Services.GoogleAnalytics.ID`に変更しました。

#### 変更点:
- `.Site.GoogleAnalytics`を`.Site.Config.Services.GoogleAnalytics.ID`に置き換えました。
- 変更により、Hugo v0.136.2以降でも問題なくビルドが通るようになります。
- README.mdのconfig.tomlのサンプルもそれに従うように変更しております。[Hugo公式ドキュメント](https://gohugo.io/methods/site/config/#services)

テーマのデザインや機能に影響を与える変更は行っておりません。

お手数ですがご確認いただければと思います。よろしくお願いいたします。
